### PR TITLE
demo2022 protocol tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,15 @@ target_include_directories(${PROJECT_NAME}_client_ros
 target_link_libraries(${PROJECT_NAME}_client_ros
     PRIVATE ${roscpp_LIBRARIES} udp_server Eigen3::Eigen)
 
+# test dummy tom client
+add_executable(${PROJECT_NAME}_dummy_client
+    src/udp_dummy_client.cpp)
+
+target_include_directories(${PROJECT_NAME}_dummy_client
+    PRIVATE ${roscpp_INCLUDE_DIRS})
+
+target_link_libraries(${PROJECT_NAME}_dummy_client
+    PRIVATE ${roscpp_LIBRARIES} udp_server Eigen3::Eigen)
 # xbot2 plugin
 #find_package(xbot2 QUIET)
 

--- a/docker/build-docker.bash
+++ b/docker/build-docker.bash
@@ -4,4 +4,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd $DIR
 
-docker build --pull --tag tom_centauro:latest . -f $DIR/Dockerfile
+docker build --pull --tag arturolaurenzi/tom_centauro:latest . -f $DIR/Dockerfile

--- a/docker/run-docker.bash
+++ b/docker/run-docker.bash
@@ -7,5 +7,5 @@ nvidia-docker run --rm -it --gpus all \
  --name tom_centauro \
  --network host \
  --privileged \
- tom_centauro:latest \
+ arturolaurenzi/tom_centauro:latest \
  x-terminal-emulator

--- a/include/tom_centauro_udp/communication/SocketBase.h
+++ b/include/tom_centauro_udp/communication/SocketBase.h
@@ -1,0 +1,251 @@
+#ifndef SOCKETBASE_H
+#define SOCKETBASE_H
+
+#pragma once
+
+#include <memory>
+#include <string.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+// Winsock Library
+#pragma comment(lib, "ws2_32.lib")
+#elif __linux__
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+// Non blocking socket
+#include <fcntl.h>
+#include <memory>
+#define SOCKET int
+#define SOCKET_ERROR (SOCKET)(-1)
+#define NO_ERROR 0
+
+#endif
+/**
+ * @brief Initialize socket object with data structure of transmission message
+ * and receiver message as template parameter TX, RX respectively.
+ *
+ * @tparam TX
+ * @tparam RX
+ */
+template <typename TX, typename RX = TX>
+class SocketBase
+{
+public:
+    virtual ~SocketBase<TX, RX>();
+
+    virtual void initialize() = 0;
+
+    /**
+     * @brief Bind socket to local address and port
+     *
+     * @param address IP address string of local node
+     * @param port port of local node
+     */
+    void bindLocal(const char *address, uint16_t port);
+
+    /**
+     * @brief Connect to remote address and port
+     * 
+     * @param address IP address string of remote node
+     * @param port port of remote node
+     */
+    void connectRemote(const char *address, uint16_t port);
+
+    /**
+     * @brief Set the Receive Buffer Size
+     *
+     * @param tx_buff
+     */
+    void setReceiveBufferSize(size_t tx_buff);
+
+    /**
+     * @brief Send data to socket
+     *
+     * @param tx
+     * @param size
+     * @return int
+     */
+    int socketSend(TX &tx, const size_t size = 0);
+
+    /**
+     * @brief Receive data from socket
+     *
+     * @param rx
+     * @param size
+     * @return int
+     */
+    int socketReceive(RX &rx, size_t size = 0);
+
+    typedef std::unique_ptr<SocketBase> ptr;
+
+protected: // protected constructor so object can not be instanciated from base class
+    /**
+     * @brief Construct a new Socket Base< TX,  RX> object
+     *
+     */
+    SocketBase<TX, RX>();
+
+    /**
+     * @brief holds byte array to be sent
+     */
+    std::unique_ptr<char[]> _tx_buffer;
+
+    /**
+     * @brief holds received byte array
+     */
+    std::unique_ptr<char[]> _rx_buffer;
+
+    size_t _tx_size;
+
+    size_t _rx_size;
+
+#ifdef _WIN32
+    WSADATA wsaData;
+#endif
+    SOCKET _socket_descriptor;
+
+    struct sockaddr_in _local_socket;
+
+    struct sockaddr_in _remote_socket;
+};
+
+// definations
+
+template <typename TX, typename RX>
+SocketBase<TX, RX>::SocketBase()
+{
+    _rx_size = sizeof(RX);
+    _rx_buffer = std::make_unique<char[]>(_rx_size);
+    _tx_size = sizeof(TX);
+    _tx_buffer = std::make_unique<char[]>(_tx_size);
+}
+
+template <typename TX, typename RX>
+SocketBase<TX, RX>::~SocketBase()
+{
+#ifdef _WIN32
+    closesocket(_socket_descriptor);
+#elif __linux__
+    close(_socket_descriptor);
+#endif
+}
+
+template <typename TX, typename RX>
+void SocketBase<TX, RX>::bindLocal(const char *address, uint16_t port)
+{
+    /* zero out structure */
+    memset((char *)(&_local_socket), 0, sizeof(_local_socket));
+
+    /* initialize address to bind */
+    _local_socket.sin_family = AF_INET;
+    _local_socket.sin_port = htons(port);
+    _local_socket.sin_addr.s_addr = inet_addr(address);
+    bzero(&(_local_socket.sin_zero), 8); /* zero the rest of the struct */
+
+    /* bind socket to address and port */
+    if (bind(_socket_descriptor, (struct sockaddr *)(&_local_socket), sizeof(_local_socket)) != NO_ERROR)
+    {
+#ifdef _WIN32
+        closesocket(_socket_descriptor);
+#elif __linux__
+        close(_socket_descriptor);
+#endif
+        throw std::runtime_error("bind() failed");
+    }
+}
+
+template <typename TX, typename RX>
+void SocketBase<TX, RX>::connectRemote(const char *address, uint16_t port)
+{
+    memset((char *)&_remote_socket, 0, sizeof(_remote_socket));
+    _remote_socket.sin_family = AF_INET;
+    _remote_socket.sin_port = htons(port);
+    _remote_socket.sin_addr.s_addr = inet_addr(address);
+
+    if (connect(_socket_descriptor, (struct sockaddr *)(&_remote_socket), sizeof(_remote_socket)) < 0)
+    {
+#ifdef _WIN32
+        closesocket(_socket_descriptor);
+#elif __linux__
+        close(_socket_descriptor);
+#endif
+        throw std::runtime_error("connect() failed");
+    }
+}
+
+template <typename TX, typename RX>
+int SocketBase<TX, RX>::socketSend(TX &tx, const size_t size)
+{
+    if (size)
+    {
+        _tx_size = size;
+    }
+
+    memcpy(_tx_buffer.get(), &tx, _tx_size);
+
+    int bytes = send(_socket_descriptor, // Connected socket
+                     _tx_buffer.get(),   // Data buffer
+                     _tx_size,           // Length of data
+                     0);
+
+    return bytes;
+}
+
+template <typename TX, typename RX>
+int SocketBase<TX, RX>::socketReceive(RX &rx, size_t size)
+{
+    if (size)
+    {
+        _rx_size = size;
+    }
+
+    /* The non blocking area */
+    fcntl(_socket_descriptor, F_SETFL, O_NONBLOCK);
+    ssize_t bytes = recv(_socket_descriptor, // Bound socket
+                         _rx_buffer.get(),   // Data buffer
+                         _rx_size,           // Length of data
+                         0);
+
+    if (bytes > 0)
+    {
+        memcpy(&rx, _rx_buffer.get(), _rx_size);
+        
+    }
+
+    return bytes;
+}
+
+template <typename TX, typename RX>
+void SocketBase<TX, RX>::setReceiveBufferSize(size_t sendBuff)
+{
+    socklen_t optlen = sizeof(int);
+    size_t sendbuff;
+
+    if (setsockopt(
+            this->_socket_descriptor, SOL_SOCKET, SO_RCVBUF, &sendbuff, sizeof(sendbuff)) == SOCKET_ERROR)
+    {
+        throw std::runtime_error("error setsockopt()");
+    }
+
+    // Get buffer size
+    auto res = getsockopt(this->_socket_descriptor, SOL_SOCKET, SO_RCVBUF, &sendbuff, &optlen);
+
+    if (res == -1)
+    {
+        throw std::runtime_error("error getsockopt()");
+    }
+    else
+    {
+        printf("revc buffer size = %d\n", sendbuff);
+    }
+}
+
+
+
+#endif

--- a/include/tom_centauro_udp/communication/TCPSocket.h
+++ b/include/tom_centauro_udp/communication/TCPSocket.h
@@ -1,0 +1,35 @@
+#ifndef TCPSOCKET_H
+#define TCPSOCKET_H
+
+#pragma once
+
+#include "SocketBase.h"
+
+template <typename TX, typename RX = TX>
+class TCPSocket : public SocketBase<TX, RX>
+{
+public:
+    TCPSocket() = default;
+
+    /**
+     * @brief initialize TCP socket connection
+     *
+     */
+    void initialize() override;
+};
+
+// definations
+
+
+template <typename TX, typename RX>
+void TCPSocket<TX, RX>::initialize()
+{
+    if ((this->_socket_descriptor = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == SOCKET_ERROR)
+    {
+        throw std::runtime_error("Could not create TCP socket");
+    }
+}
+
+
+
+#endif

--- a/include/tom_centauro_udp/communication/UDPSocket.h
+++ b/include/tom_centauro_udp/communication/UDPSocket.h
@@ -1,0 +1,85 @@
+#ifndef UDPSOCKET_H
+#define UDPSOCKET_H
+
+#pragma once
+
+#include "SocketBase.h"
+
+template <typename TX, typename RX = TX>
+class UDPSocket : public SocketBase<TX, RX>
+{
+public:
+    UDPSocket() = default;
+    /**
+     * @brief Initialize UDP socket connection
+     * 
+     */
+    void initialize() override;
+    /**
+     * @brief Set the UDP Receive Buffer Size object
+     * 
+     * @param rx_buffer 
+     */
+    void setReceiveBufferSize(size_t &rx_buffer);
+};
+
+// definations
+
+template <typename TX, typename RX>
+void UDPSocket<TX, RX>::initialize()
+{
+
+#ifdef _WIN32
+    /* Initialize Winsock */
+    // consoleLog->info("Initialising Winsock...");
+    if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0)
+    {
+        WSACleanup();
+        // init failed;
+    }
+#endif
+
+    // create socket
+    if ((this->_socket_descriptor = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == SOCKET_ERROR)
+    {
+        perror("socket() udp");
+        throw std::runtime_error("socket() UDP");
+    }
+
+#ifdef __linux__
+    int option = 1;
+    /* Non-blocking */
+    ioctl(this->_socket_descriptor, FIONBIO, &option);
+
+    // Non-blocking//
+    // int flags = fcntl(this->_socket_descriptor, F_GETFL, 0);
+    // fcntl(this->_socket_descriptor, F_SETFL, flags | O_NONBLOCK);
+#endif
+}
+
+template <typename TX, typename RX>
+void UDPSocket<TX, RX>::setReceiveBufferSize(size_t &tx_buffer)
+{
+    socklen_t optlen = sizeof(int);
+    //size_t tx_buffer;
+
+    if (setsockopt(this->_socket_descriptor, SOL_SOCKET, SO_RCVBUF, &tx_buffer, sizeof(tx_buffer)) == SOCKET_ERROR)
+    {
+        throw std::runtime_error("error setsockopt()");
+    }
+
+    // Get buffer size
+    auto res = getsockopt(this->_socket_descriptor, SOL_SOCKET, SO_RCVBUF, &tx_buffer, &optlen);
+
+    if (res == -1)
+    {
+        throw std::runtime_error("error getsockopt()");
+    }
+    else
+    {
+        printf("revc buffer size = %d\n", tx_buffer);
+    }
+}
+
+
+#endif

--- a/include/tom_centauro_udp/packet/packet.hpp
+++ b/include/tom_centauro_udp/packet/packet.hpp
@@ -22,11 +22,18 @@ struct __attribute__((packed)) master2slave
     float position_x;
     float position_y;
     float position_z;
-    float rotation[9];  // column major ordering
+    //float rotation[9];    // column major ordering
+    float rotation[4];      // quaternion (w, xi, yj, zk)
 
     // hand command (desired pos, desired force?)
     float gripper_pos;
     float gripper_force;
+    
+    // jostick commands
+    bool jst_button[3];
+    float jst_axes[2];      // raw joystick x,y data [-1 to 1]
+    float aux_heading;      // posiible centauro heading command (rotatate about z axis)
+    float aux_pos[2];       // posible centtaoro velocity/direction command (x,y)
 
     // simple check code
     uint32_t magic_code = expected_magic_code;
@@ -52,11 +59,17 @@ struct __attribute__((packed)) slave2master
     float position_x;
     float position_y;
     float position_z;
-    float rotation[9];  // column major ordering
+    //float rotation[9];    // column major ordering
+    float rotation[4];      // quaternion (w, xi, yj, zk)
 
     // hand feedback
     float gripper_pos;
     float gripper_force;
+
+
+    // jostick commands
+    float aux_heading;      // posiible centauro heading state (rotatate about z axis)
+    float aux_pos[2];       // posible centtaoro velocity/direction state (x,y)
 
     // simple check code
     uint32_t magic_code = expected_magic_code;

--- a/include/tom_centauro_udp/packet/packet_ros_utils.hpp
+++ b/include/tom_centauro_udp/packet/packet_ros_utils.hpp
@@ -47,7 +47,12 @@ void fill_pkt_with_pose(packet_t& pkt,
 
     q.normalize();
 
-    Eigen::Matrix3f::Map(pkt.rotation) = q.toRotationMatrix();
+    // Eigen::Matrix3f::Map(pkt.rotation) = q.toRotationMatrix();
+
+    pkt.rotation[0] = q.w();
+    pkt.rotation[1] = q.x();
+    pkt.rotation[2] = q.y();
+    pkt.rotation[3] = q.z();
 
 }
 
@@ -59,11 +64,19 @@ void get_pose_from_pkt(packet_t& pkt,
     pose.pose.position.y = pkt.position_y;
     pose.pose.position.z = pkt.position_z;
 
-    Eigen::Quaternionf q(Eigen::Matrix3f::Map(pkt.rotation));
-    pose.pose.orientation.x = q.x();
-    pose.pose.orientation.y = q.y();
-    pose.pose.orientation.z = q.z();
-    pose.pose.orientation.w = q.w();
+    // Eigen::Quaternionf q(Eigen::Matrix3f::Map(pkt.rotation));
+
+    Eigen::Quaternionf q(pkt.rotation[0],
+                         pkt.rotation[1],
+                         pkt.rotation[2],
+                         pkt.rotation[3]);
+
+    q.normalize();
+
+    pose.pose.orientation.x = q.w();
+    pose.pose.orientation.y = q.x();
+    pose.pose.orientation.z = q.y();
+    pose.pose.orientation.w = q.z();
 }
 
 }

--- a/src/udp_dummy_client.cpp
+++ b/src/udp_dummy_client.cpp
@@ -1,0 +1,102 @@
+#include "tom_centauro_udp/packet/packet.hpp"
+#include "tom_centauro_udp/packet/packet_ros_utils.hpp"
+
+#include "tom_centauro_udp/communication/UDPSocket.h"
+
+#include <ros/ros.h>
+#include <chrono>
+#include <thread>
+
+int main(int argc, char *argv[])
+{
+    ros::init(argc, argv, "udp_dummy_ros");
+    ros::NodeHandle nh;
+
+    // udp non blocking socket
+    UDPSocket<tom_centauro_udp::packet::master2slave, tom_centauro_udp::packet::slave2master> udp_socket;
+
+    // ToM address (change it to your local ip)
+    const std::string local_address = "192.168.10.101";
+    const int local_port = 8080;
+
+    // Centauro address
+    const std::string remote_address = "192.168.10.101";
+    const int remote_port = 8081;
+
+    udp_socket.initialize();
+    udp_socket.bindLocal(local_address.c_str(), local_port);
+    udp_socket.connectRemote(remote_address.c_str(), remote_port);
+
+    // reference message from ToM to Centauro
+    tom_centauro_udp::packet::master2slave packet_to_robot;
+    // state message from Centauro to ToM
+    tom_centauro_udp::packet::slave2master packet_to_tom;
+
+    // end effector frame to be controlled
+    const std::string ee_id = "arm2_8";
+
+    tom_centauro_udp::fill_pkt_ee_id(packet_to_robot, ee_id);
+    packet_to_robot.rotation[0] = 1;
+
+    packet_to_robot.run = false;
+
+    ros::Subscriber ee_sub = nh.subscribe<geometry_msgs::PoseStamped>(
+        "/cartesian/arm2_8/reference", 1,
+        [&](const auto &msg)
+        {
+            ROS_INFO_THROTTLE(1, "cartesian/arm2_8/reference");
+        });
+
+    auto tx_callback = [&]()
+    {
+        // thead callback to send reference
+        auto next = std::chrono::high_resolution_clock::now();
+        while (ros::ok())
+        {
+            // packet_to_robot.position_z = sin(next.time_since_epoch().count());
+            udp_socket.socketSend(packet_to_robot);
+
+            ros::spinOnce();
+            next = next + std::chrono::milliseconds(10);
+            std::this_thread::sleep_until(next);
+        }
+    };
+
+    double t = 0;
+    const double dt = 0.001;
+    const double period = 3.0;
+    const double amplitude = 0.01;
+
+    auto rx_callback = [&]()
+    {
+        // non blocking receive thead callback to receive current robot state
+        auto next = std::chrono::high_resolution_clock::now();
+        while (ros::ok())
+        {
+            int ret = udp_socket.socketReceive(packet_to_tom, sizeof(packet_to_tom));
+            if (ret >= sizeof(packet_to_tom))
+            {
+                packet_to_robot.run = true;
+                packet_to_robot.position_z = packet_to_tom.position_z + amplitude * std::sin(2.0 * M_PI * t / period);
+                packet_to_robot.position_x = packet_to_tom.position_x;
+                packet_to_robot.position_y = packet_to_tom.position_y + amplitude * std::cos(2.0 * M_PI * t / period);
+            }
+            else
+            {
+
+                // packet_to_robot.run =false;
+            }
+            // std::cout << packet_to_tom.position_x << std::endl;
+            t = t + dt;
+            next = next + std::chrono::milliseconds(1);
+            std::this_thread::sleep_until(next);
+        }
+    };
+
+    std::thread tx_thread(tx_callback);
+    std::thread rx_thread(rx_callback);
+    tx_thread.join();
+    rx_thread.join();
+
+    return 0;
+}


### PR DESCRIPTION
Hi,
Provided docker image is perfect,  as we discussed, rotation reference in protocol [(packet.hpp)](https://github.com/ADVRHumanoids/TomCentauroUDP/blob/demo2022/include/tom_centauro_udp/packet/packet.hpp) has been updated to assume Quaternion instead of rotation matrix, and shall be filled with following order.
```
rotation[0]  = q.w;  // real part
rotation[1]  = q.x;
rotation[2]  = q.y; 
rotation[3]  = q.z; 
````

apart from rotations, there are few entries reserved for joystick that might be sent from ToM to Centauro, to orient Centauro heading and Cartesian position of base.